### PR TITLE
Inclure samedi 2016-04-02 dans vacances printemps

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -9587,7 +9587,7 @@ date,vacances_zone_a,vacances_zone_b,vacances_zone_c,nom_vacances
 2016-03-30,False,False,False,
 2016-03-31,False,False,False,
 2016-04-01,False,False,False,
-2016-04-02,False,False,False,
+2016-04-02,False,True,False,Vacances de printemps
 2016-04-03,False,True,False,Vacances de printemps
 2016-04-04,False,True,False,Vacances de printemps
 2016-04-05,False,True,False,Vacances de printemps


### PR DESCRIPTION
D'après l'[Arrêté du 21 janvier 2014 fixant le calendrier scolaire des années 2014-2015, 2015-2016 et 2016-2017](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000028508429#LEGIARTI000030489228), le samedi 2 avril 2016 fait partie des vacances scolaires de printemps de la zone B.